### PR TITLE
Fix release.sh on pristine macOS Monterey

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -24,8 +24,8 @@ let package = Package(
       .binaryTarget(
           name: "lightarti-rest",
           // The following two comments are needed for the automatic update to work!
-          url: "https://github.com/c4dt/lightarti-rest/releases/download/0.4.3/lightarti-rest.xcframework.zip", // XCFramework URL
-          checksum: "80900618b75b3f781f55153e30b736321216bfd7cce15df9aa2888732b14e303" // XCFramework checksum
+          url: "https://github.com/tladesignz/lightarti-rest/releases/download/0.4.5/lightarti-rest.xcframework.zip", // XCFramework URL
+          checksum: "79550e58762f107d595f0ee8dce9c7aa0c39f01d7ea43a65c7754a21fb68ae94" // XCFramework checksum
 	   ),
 // This is for local testing
 

--- a/release.sh
+++ b/release.sh
@@ -23,7 +23,8 @@ get_next(){
 
 get_next_tag(){
   local RELEASE=$1
-  get_next "$( echo "$RELEASE" | jq -r '.tag_name')" "$( git tag | tail -n 1)"
+  local TAG=$( git tag | tail -n 1 )
+  get_next "$( echo "$RELEASE" | jq -r '.tag_name' )" "${TAG:-0.1.0}"
 }
 
 # Check if the repo is committed
@@ -34,10 +35,10 @@ fi
 
 # Get latest release of lightarti rest and update the Package.swift with the
 # hash and the url
-RELEASE=$( curl -sL https://api.github.com/repos/c4dt/lightarti-rest/releases/latest )
+RELEASE=$( curl -sL https://api.github.com/repos/tladesignz/lightarti-rest/releases/latest )
 XCFRAMEWORK_URL=$( echo "$RELEASE" | jq -r '.assets[].browser_download_url')
 echo "URL is: $XCFRAMEWORK_URL"
-CHK=$(curl -s -L "$XCFRAMEWORK_URL" | sha256sum | cut -d' ' -f1)
+CHK=$(curl -s -L "$XCFRAMEWORK_URL" | shasum -a 256 | cut -d' ' -f1)
 echo "Checksum is: $CHK"
 
 # Get the next tag


### PR DESCRIPTION
Ignore my changes to the `binaryTarget` which I just did for testing my changes to `lightarti-rest`.

However, while trying this out, I could only get this to run on my macOS Monterey with the changes you can see in `release.sh`.

It seems `sha256sum` is not available (anymore).
The change in `get_next_tag` might by a problem of bash vs. zsh (the new default)

You might want to adapt maybe?

